### PR TITLE
feat: add option to validate key order

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ This is a [Node.js](https://nodejs.org/) module available through the
 npm install @github-docs/frontmatter
 ```
 
+## Features
+
+- Make frontmatter entries required or optional
+- Validate value type, length, pattern, etc. See the [revalidator#schema](https://github.com/flatiron/revalidator#schema).
+- Validate urls, emails, IP addresses, dates, times, etc. See [revalidator#format](https://github.com/flatiron/revalidator#format).
+- Set an explicit list of allowable values with [`enum`](https://github.com/flatiron/revalidator#enum).
+- Enforce a specific order of frontmatter values with `validateKeyOrder`
+- Disallow values that are not specified in the schema with `validateKeyNames`
+
 ## Usage
 
 ```js

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,5 @@
 const parse = require('..')
-
+const filepath = 'path/to/file.md'
 const fixture1 = `---
 title: Hello, World
 meaning_of_life: 42
@@ -9,44 +9,129 @@ I am content.
 `
 
 describe('frontmatter', () => {
-  it('parses frontmatter and content in a given string', () => {
-    const { data, content } = parse(fixture1)
+  it('parses frontmatter and content in a given string (no options required)', () => {
+    const { data, content, errors } = parse(fixture1)
     expect(data.title).toBe('Hello, World')
     expect(data.meaning_of_life).toBe(42)
     expect(content.trim()).toBe('I am content.')
+    expect(errors.length).toBe(0)
   })
 
-  it('accepts an optional schema for validation', () => {
+  describe('schema', () => {
+    it('is optional', () => {
+      const schema = {
+        properties: {
+          title: {
+            type: 'string'
+          },
+          meaning_of_life: {
+            type: 'number'
+          }
+        }
+      }
+
+      const { data, content, errors } = parse(fixture1, { schema })
+      expect(data.title).toBe('Hello, World')
+      expect(data.meaning_of_life).toBe(42)
+      expect(content.trim()).toBe('I am content.')
+      expect(errors.length).toBe(0)
+    })
+
+    it('creates errors if frontmatter does not conform to schema', () => {
+      const schema = {
+        properties: {
+          meaning_of_life: {
+            type: 'number',
+            minimum: 50
+          }
+        }
+      }
+
+      const { data, content, errors } = parse(fixture1, { schema })
+      expect(data.title).toBe('Hello, World')
+      expect(data.meaning_of_life).toBe(42)
+      expect(content.trim()).toBe('I am content.')
+      expect(errors.length).toBe(1)
+      const expectedError = {
+        attribute: 'minimum',
+        property: 'meaning_of_life',
+        expected: 50,
+        actual: 42,
+        message: 'must be greater than or equal to 50'
+      }
+      expect(errors[0]).toEqual(expectedError)
+    })
+  })
+
+  describe('validateKeyNames', () => {
     const schema = {
       properties: {
-        meaning_of_life: {
-          type: 'number',
-          minimum: 50
+        age: {
+          type: 'number'
         }
       }
     }
 
-    const { data, content, errors } = parse(fixture1, { schema })
-    expect(data.title).toBe('Hello, World')
-    expect(data.meaning_of_life).toBe(42)
-    expect(errors.length).toBe(1)
-    const expectedError = {
-      attribute: 'minimum',
-      property: 'meaning_of_life',
-      expected: 50,
-      actual: 42,
-      message: 'must be greater than or equal to 50'
-    }
-    expect(errors[0]).toEqual(expectedError)
+    it('creates errors for undocumented keys if `validateKeyNames` is true', () => {
+      const { errors } = parse(fixture1, { schema, validateKeyNames: true, filepath })
+      expect(errors.length).toBe(2)
+      const expectedErrors = [
+        {
+          property: 'title',
+          message: 'not allowed. Allowed properties are: age',
+          filepath: 'path/to/file.md'
+        },
+        {
+          property: 'meaning_of_life',
+          message: 'not allowed. Allowed properties are: age',
+          filepath: 'path/to/file.md'
+        }
+      ]
+      expect(errors).toEqual(expectedErrors)
+    })
 
-    expect(content.trim()).toBe('I am content.')
+    it('does not create errors for undocumented keys if `validateKeyNames` is false', () => {
+      const { errors } = parse(fixture1, { schema, validateKeyNames: false })
+      expect(errors.length).toBe(0)
+    })
   })
 
-  it.todo('creates errors for undocumented keys if `validateKeyNames` is true')
+  describe('validateKeyOrder', () => {
+    it('creates errors if `validateKeyOrder` is true and keys are not in order', () => {
+      const schema = {
+        properties: {
+          meaning_of_life: {
+            type: 'number'
+          },
+          title: {
+            type: 'string'
+          }
+        }
+      }
+      const { errors } = parse(fixture1, { schema, validateKeyOrder: true, filepath })
+      const expectedErrors = [
+        {
+          property: 'keys',
+          message: 'keys must be in order. Current: title,meaning_of_life; Expected: meaning_of_life,title',
+          filepath: 'path/to/file.md'
+        }
+      ]
+      expect(errors).toEqual(expectedErrors)
+    })
 
-  it.todo('validates key order if `validateKeyOrder` is true')
-
-  it.todo('includes filepath in schema validation errors, if specified')
-
-  it.todo('includes filepath in key name validation errors, if specified')
+    it('does not create errors if `validateKeyOrder` is true and keys are in order', () => {
+      const schema = {
+        properties: {
+          title: {
+            type: 'string'
+          },
+          meaning_of_life: {
+            type: 'number'
+          }
+        }
+      }
+      const { errors } = parse(fixture1, { schema, validateKeyOrder: true })
+      expect(errors.length).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds support for the `validateKeyOrder` option. It defaults to `false`. When set to `true`, the `errors` array will include an error if the order of keys in the schema differs from the order of the keys in the given file.

This PR also adds more test coverage for other stuff.