### PR TITLE
feat: stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ const { data, content, errors } = frontmatter(markdown)
 
 ## API
 
-This module exports a single function:
-
 ### `frontmatter(markdown, [options])`
+
+Parses a string containing markdown and (optional) frontmatter.
 
 - `markdown` String (required) - the contents of a markdown file that includes YAML frontmatter.
 - `options` Object (optional)
@@ -64,6 +64,11 @@ This module exports a single function:
   - `filepath` String - The name of the file being parsed. Useful for debugging when errors occur.
   - `validateKeyNames` Boolean - If `true`, checks that all keys are specified as schema properties. Defaults to `false`
   - `validateKeyOrder` Boolean - If `true`, checks that all keys are in the same order they appear in the schema. Defaults to `false`
+
+
+### `frontmatter.stringify(markdown, [data])`
+
+This is the same [`stringify`](https://github.com/jonschlinkert/gray-matter#stringify) method exported by the `gray-matter` module, which can be used to join a markdown string and a frontmatter object together as a single string.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const matter = require('gray-matter')
 const revalidator = require('revalidator')
 const { difference, intersection } = require('lodash')
 
-module.exports = function frontmatter (markdown, opts = { validateKeyNames: false, validateKeyOrder: false }) {
+function frontmatter (markdown, opts = { validateKeyNames: false, validateKeyOrder: false }) {
   const schema = opts.schema || { properties: {} }
   const filepath = opts.filepath || null
   const { content, data } = matter(markdown)
@@ -42,3 +42,11 @@ module.exports = function frontmatter (markdown, opts = { validateKeyNames: fals
 
   return { content, data, errors }
 }
+
+// Expose gray-matter's underlying stringify method for joining a parsed
+// frontmatter object and a markdown string back into a unified string
+//
+// stringify('some string', {some: 'frontmatter'})
+frontmatter.stringify = matter.stringify
+
+module.exports = frontmatter

--- a/tests/index.js
+++ b/tests/index.js
@@ -17,6 +17,12 @@ describe('frontmatter', () => {
     expect(errors.length).toBe(0)
   })
 
+  describe('frontmatter.stringify', () => {
+    it('is exported', () => {
+      expect(typeof parse.stringify).toBe('function')
+    })
+  })
+
   describe('schema', () => {
     it('is optional', () => {
       const schema = {


### PR DESCRIPTION
This PR exposes the `stringify` method from gray-matter, so it can be accessed when using `@github-docs/frontmatter` without having to dig into the internal gray-matter. API.

Resolves #6 

cc @juliangruber @sarahs 