### PR TITLE
fix: catch YML parsing errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,12 @@ function frontmatter (markdown, opts = { validateKeyNames: false, validateKeyOrd
   try {
     ({ content, data } = matter(markdown))
   } catch (e) {
-    // make this common error message a little easier to understand
-    const reason = e.reason.startsWith('can not read a block mapping entry;')
-      ? 'invalid frontmatter entry'
-      : e.reason
+    const defaultReason = 'invalid frontmatter entry'
+
+    const reason = e.reason
+      // make this common error message a little easier to understand
+      ? e.reason.startsWith('can not read a block mapping entry;') ? defaultReason : e.reason
+      : defaultReason
 
     const error = {
       reason,

--- a/index.js
+++ b/index.js
@@ -5,12 +5,33 @@ const { difference, intersection } = require('lodash')
 function frontmatter (markdown, opts = { validateKeyNames: false, validateKeyOrder: false }) {
   const schema = opts.schema || { properties: {} }
   const filepath = opts.filepath || null
-  const { content, data } = matter(markdown)
+
+  let content, data
+  let errors = []
+
+  try {
+    ({ content, data } = matter(markdown))
+  } catch (e) {
+    // make this common error message a little easier to understand
+    const reason = e.reason.startsWith('can not read a block mapping entry;')
+      ? 'invalid frontmatter entry'
+      : e.reason
+
+    const error = {
+      reason,
+      message: 'YML parsing error!'
+    }
+
+    if (filepath) error.filepath = filepath
+    errors.push(error)
+    return { errors }
+  }
+
   const allowedKeys = Object.keys(schema.properties)
   const existingKeys = Object.keys(data)
   const expectedKeys = intersection(allowedKeys, existingKeys)
 
-  let { errors } = revalidator.validate(data, schema)
+  ;({ errors } = revalidator.validate(data, schema))
 
   // add filepath property to each error object
   if (errors.length && filepath) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -23,6 +23,43 @@ describe('frontmatter', () => {
     })
   })
 
+  describe('YML parsing errors', () => {
+    it('creates errors if YML has an unescaped quote', () => {
+      const fixture = `---
+intro: 'I've got an unescaped quote'
+---
+
+I am content.
+`
+      const { errors } = parse(fixture, { filepath })
+      expect(errors.length).toBe(1)
+      const expectedError = {
+        filepath: 'path/to/file.md',
+        message: 'YML parsing error!',
+        reason: 'invalid frontmatter entry'
+      }
+      expect(errors[0]).toEqual(expectedError)
+    })
+
+    it('creates errors if YML has incorrect indentation', () => {
+      const fixture = `---
+title: Hello, World
+ intro: 'I have a bad leading space'
+---
+
+I am content.
+`
+      const { errors } = parse(fixture, { filepath })
+      expect(errors.length).toBe(1)
+      const expectedError = {
+        filepath: 'path/to/file.md',
+        message: 'YML parsing error!',
+        reason: 'bad indentation of a mapping entry'
+      }
+      expect(errors[0]).toEqual(expectedError)
+    })
+  })
+
   describe('schema', () => {
     it('is optional', () => {
       const schema = {


### PR DESCRIPTION
This PR adds a try/catch around the call to `gray-matter`, and adds the filepath to the error message.

For example, unescaped quotes in frontmatter are a common problem. The error surfaced by `js-yaml` for these is:

```
YAMLException: can not read a block mapping entry; a multiline key may not be an implicit key
```

This is a little confusing, so this PR sets the message to `invalid frontmatter entry` instead. 

The default messages for other errors is clearer (e.g., `bad indentation of a mapping entry`), so this PR leaves those as is.

@zeke I'm not tied to this if you see a better approach.