### PR TITLE
fix: create semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release npm package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
semantic-release was originally set up in https://github.com/docs/frontmatter/pull/2, with Travis as the release platform.

Four days ago I removed the Travis config in https://github.com/docs/frontmatter/pull/10 without noticing that it was being used for anything other than running tests.

This PR adds a new release.yml Actions workflow file to replace the missing Travis setup.

cc @sarahs 